### PR TITLE
Lowered the size of presumably "too large" disks, from 1 TB down to ...

### DIFF
--- a/src/gmw-main.c
+++ b/src/gmw-main.c
@@ -1511,7 +1511,7 @@ gmw_udisks_object_add (GmwPrivate *priv, GDBusObject *dbus_object)
 			 block_path, (guint) device_size);
 		return FALSE;
 	}
-	if (device_size > 1024 * 1024) {
+	if (device_size > 64 * 1024) {
 		g_debug ("%s is too large [%u]",
 			 block_path, (guint) device_size);
 		return FALSE;


### PR DESCRIPTION
…64 GB, which better fits the documentation files.

Hello, when I tried to use gnome-multi-write with my machine, I was surprised to find two disks of one tera-Byte listed as possible targets for writing. Of course I do not want to modify those disks which are part of my working system.

As the main documentation states that "Supported drive sizes are between 1GB and 32GB", I have defined a lower high limit for the disk size (64 GB thumb drives become affordable for some people now, and still few people will buy 64 GB disks as an external storage to work like their main internal hard disk).

Please can you consider this pull request?

By the way, would it be wise to present non-target disks, like SD flash cards, or bigger USB disks, as initially disabled, with a possibility left to enable them, for the end user?
